### PR TITLE
#29 fix: 마이프로필 화면이동시 갇히는 오류 해결

### DIFF
--- a/TrackUs/TrackUs/Sources/MyProfile/View/ProfileEditView.swift
+++ b/TrackUs/TrackUs/Sources/MyProfile/View/ProfileEditView.swift
@@ -92,6 +92,7 @@ struct ProfileEditView: View {
                                 }
                                 .accentColor(.gray1)
                                 .padding(.horizontal, -8)
+                                
                             }
                             
                             HStack {
@@ -137,9 +138,7 @@ struct ProfileEditView: View {
                 Text("프로필 변경")
                     .customFontStyle(.gray1_SB16)
             } left: {
-                NavigationLink(destination: MyProfileView()) {
-                    NavigationBackButton()
-                }
+                NavigationBackButton()
             }
             MainButton(active: true, buttonText: "수정완료", action: modifyButtonTapped)
                 .padding(Constants.ViewLayout.VIEW_STANDARD_HORIZONTAL_SPACING)

--- a/TrackUs/TrackUs/Sources/Root/TrackUsApp.swift
+++ b/TrackUs/TrackUs/Sources/Root/TrackUsApp.swift
@@ -10,11 +10,10 @@ import SwiftUI
 @main
 struct TrackUsApp: App {
     var body: some Scene {
-        @StateObject var router = Router()
         
         WindowGroup {
             ContentView()
-                .environmentObject(router)
+                .environmentObject(Router())
         }
     }
 }


### PR DESCRIPTION
## 이슈번호
#29 

## 마이프로필 화면이동시 갇히는 오류 해결

### 처리내용
NavigationPath를 직접 비워주지 않는 문제로 확인하여 처리 했습니다.

```swift
 .customNavigation {
                Text("프로필 변경")
                    .customFontStyle(.gray1_SB16)
            } left: {
                NavigationBackButton()
            }
```